### PR TITLE
Use array_key_exists to check if key exists

### DIFF
--- a/src/Big.php
+++ b/src/Big.php
@@ -176,7 +176,7 @@ class Big
 
             // If we have an id column use Google's insertId
             // https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataconsistency
-            if (in_array('id', $item)) {
+            if (array_key_exists('id', $item)) {
                 $rowData = [
                     'insertId' => $item['id'],
                     'data' => $item,


### PR DESCRIPTION
This prevents an exception when you have another column that contains an
id but doesn't have a value declared as `id`.

This may be a non-issue but I have just encountered this myself.