### PR TITLE
Hotfix/move job configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2018-8-16
+### Changed
+- Fixed Job Configuration options
+
 ## [1.0.0] - 2018-4-19
 ### Added
 - Added nullable/required field modes.

--- a/src/Big.php
+++ b/src/Big.php
@@ -72,7 +72,7 @@ class Big
         // Set default options if nothing is passed in
         $options = $options ?? $this->options;
 
-        $queryResults = $this->query->runQuery($this->query->query($query), $options);
+        $queryResults = $this->query->runQuery($this->query->query($query, $options));
 
         // Setup our result checks
         $isComplete = $queryResults->isComplete();


### PR DESCRIPTION
While the runQuery and query methods both allow for a Job Configuration Options parameter, only the query method's options parameter appears to actually modify properties of the query in a way that is respected by the BigQuery API.

This will create unexpected behaviour currently if, for example, you set useLegacySql to true, because the PHP BigQuery client default is false. Since query is the method responsible for returning a new QueryJobConfiguration object, if no options parameters for that value is provided, it will assert the default value as false, and your options will be ignored when the query is made.

If we simply place the options parameter into the query method, instead of the runQuery method, our Job Configuration Options are correctly respected.